### PR TITLE
Split server_setting defined type to separate file

### DIFF
--- a/manifests/properties.pp
+++ b/manifests/properties.pp
@@ -1,32 +1,20 @@
 class minecraft::properties {
 
-  define server_setting {
-    file { $title :
-      ensure  => file,
-      path    => "${minecraft::install_dir}/${title}",
-      content => template("minecraft/${title}.erb"),
-      owner   => $minecraft::user,
-      group   => $minecraft::group,
-      mode    => '0664',
-      require => User[$minecraft::user],
-    }
-  }
-
-  server_setting { 'server.properties': }
+  minecraft::server_setting { 'server.properties': }
 
   if $minecraft::ops != undef {
-    server_setting { 'ops.txt': }
+    minecraft::server_setting { 'ops.txt': }
   }
 
   if $minecraft::banned_players != undef {
-    server_setting { 'banned-players.txt': }
+    minecraft::server_setting { 'banned-players.txt': }
   }
 
   if $minecraft::banned_ips != undef {
-    server_setting { 'banned-ips.txt': }
+    minecraft::server_setting { 'banned-ips.txt': }
   }
 
   if $minecraft::white_list_players != undef {
-    server_setting { 'white-list.txt': }
+    minecraft::server_setting { 'white-list.txt': }
   }
 }

--- a/manifests/server_setting.pp
+++ b/manifests/server_setting.pp
@@ -1,0 +1,12 @@
+define minecraft::server_setting {
+  file { $title :
+    ensure  => file,
+    path    => "${minecraft::install_dir}/${title}",
+    content => template("minecraft/${title}.erb"),
+    owner   => $minecraft::user,
+    group   => $minecraft::group,
+    mode    => '0664',
+    require => User[$minecraft::user],
+  }
+}
+


### PR DESCRIPTION
This wasn't working on puppet 4, but when I split out the defined type
it fixed it.