### PR TITLE
Fix init file for ubuntu

### DIFF
--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -1,6 +1,7 @@
 define minecraft::plugin(
   $source,
-  $plugin_name  = $title
+  $plugin_name  = $title,
+  $ensure       = present
 ) {
 
   if $plugin_name =~ /^.*\.jar$/ {
@@ -8,7 +9,7 @@ define minecraft::plugin(
   }
 
   archive { $plugin_name:
-    ensure  => 'present',
+    ensure  => $ensure,
     source  => $source,
     path    => "${::minecraft::install_dir}/plugins/${plugin_name}.jar",
     notify  => Service['minecraft'],
@@ -16,8 +17,14 @@ define minecraft::plugin(
     user    => $::minecraft::user,
   }
 
+  if $ensure == present {
+    $jar_ensure = file
+  } else {
+    $jar_ensure = $ensure
+  }
+
   file { "${::minecraft::install_dir}/plugins/${plugin_name}.jar":
-    ensure  => 'file',
+    ensure  => $jar_ensure,
     owner   => $::minecraft::user,
     group   => $::minecraft::group,
     mode    => '0644',

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -12,6 +12,6 @@ class minecraft::service {
   service { 'minecraft':
     ensure    => running,
     enable    => $minecraft::autostart,
-    subscribe => File[ 'server.properties', 'minecraft_init' ],
+    subscribe => File['minecraft_init' ],
   }
 }

--- a/manifests/source.pp
+++ b/manifests/source.pp
@@ -38,4 +38,11 @@ class minecraft::source {
     ],
   }
 
+  file { "${minecraft::install_dir}/eula.txt":
+    ensure  => file,
+    owner   => $minecraft::user,
+    group   => $minecraft::group,
+    content => template('minecraft/eula.txt.erb'),
+  }
+
 }

--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppetlabs-java",
-      "version_requirement": "0.1.6"
+      "version_requirement": ">=1.6.0"
     },
     {
       "name": "puppet-archive",
@@ -33,7 +33,8 @@
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
         "12.04",
-        "14.04"
+        "14.04",
+        "16.04"
       ]
     },
     {

--- a/templates/eula.txt.erb
+++ b/templates/eula.txt.erb
@@ -1,0 +1,1 @@
+eula=true

--- a/templates/minecraft_init.erb
+++ b/templates/minecraft_init.erb
@@ -1,17 +1,15 @@
 #!/bin/bash
-# /etc/init.d/minecraft
-
-  ### BEGIN INIT INFO
-  # Provides:   minecraft
-  # Required-Start: $local_fs $remote_fs
-  # Required-Stop:  $local_fs $remote_fs
-  # Should-Start:   $network
-  # Should-Stop:    $network
-  # Default-Start:  2 3 4 5
-  # Default-Stop:   0 1 6
-  # Short-Description:    Minecraft server
-  # Description:    Starts the minecraft server
-  ### END INIT INFO
+### BEGIN INIT INFO
+# Provides:   minecraft
+# Required-Start: $local_fs $remote_fs
+# Required-Stop:  $local_fs $remote_fs
+# Should-Start:   $network
+# Should-Stop:    $network
+# Default-Start:  2 3 4 5
+# Default-Stop:   0 1 6
+# Short-Description:    Minecraft server
+# Description:    Starts the minecraft server
+### END INIT INFO
 
 #Settings
 SERVICE='minecraft_server.jar'

--- a/templates/ops.txt.erb
+++ b/templates/ops.txt.erb
@@ -1,5 +1,3 @@
-# Managed by Puppet! Changes made manually may be lost.
-
 <% scope['minecraft::ops'].each do |op| -%>
 <%= op %>
 <% end -%>


### PR DESCRIPTION
This should sort out some of the issues in #25 

For some reason the whitespace in the init script was throwing off the enable => true hence why I de-indented it.

Still working on using either file_line or augeas for the new ```server.properties``` entries but have removed the ```Service['minecraft']``` subscription for now. It was triggering a server restart each puppet run.

Anything with "#managed by puppet" gets clobbered by the server when it reads and rewrites to them when starting up so had to remove it :/