### PR TITLE
system accounts for user and groups

### DIFF
--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -1,7 +1,8 @@
 class minecraft::user {
 
   group { $minecraft::group:
-    ensure     => present,
+    ensure => present,
+    system => true,
   }
 
   user { $minecraft::user:
@@ -9,6 +10,7 @@ class minecraft::user {
     gid        => $minecraft::group,
     home       => $minecraft::install_dir,
     managehome => true,
+    system     => true,
     require    => Group[$minecraft::group],
   }
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe 'minecraft' do
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) do
+        facts
+      end
+      context 'with defaults for all parameters' do
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_group('minecraft').with_system(true) }
+        it { is_expected.to contain_user('minecraft').with_system(true) }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Set `system => true` for minecraft user
and group to ensure a suitable uid and gid
is chosen.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
