### PR TITLE
WIP: Use a systemd unit on supported systemd

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,17 +1,25 @@
 class minecraft::service {
 
-  file { 'minecraft_init':
-    ensure  => present,
-    path    => '/etc/init.d/minecraft',
-    owner   => 'root',
-    group   => 'root',
-    mode    => '0744',
-    content => template('minecraft/minecraft_init.erb'),
+
+  if $facts['systemd'] {
+    ::systemd::unit_file { 'minecraft.service':
+      content => template('minecraft/minecraft.service.erb'),
+      notify  => Service['minecraft'],
+    }
+  } else {
+    file { 'minecraft_init':
+      ensure  => present,
+      path    => '/etc/init.d/minecraft',
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0744',
+      content => template('minecraft/minecraft_init.erb'),
+      notify  => Service['minecraft'],
+    }
   }
 
   service { 'minecraft':
     ensure    => running,
     enable    => $minecraft::autostart,
-    subscribe => File['minecraft_init' ],
   }
 }

--- a/templates/minecraft.service.erb
+++ b/templates/minecraft.service.erb
@@ -1,0 +1,17 @@
+#Puppet generated minecraft unit.
+
+[Unit]
+Description=Minecraft server
+After=local-fs.target network.target
+
+[Service]
+WorkingDirectory=<%= scope['minecraft::install_dir'] %>
+User=<%= scope['minecraft::user'] %>
+Type=simple
+Environment=MIN_HEAP=<%= scope['minecraft::heap_start'] %>
+Environment=MAX_HEAP=<%= scope['minecraft::heap_size'] %>
+ExecStart=/usr/bin/java -Xmx${MAX_HEAP}M -Xms${MIN_HEAP}M -jar minecraft_server.jar nogui
+ExecStop=<%= scope['minecraft::install_dir'] %>/mcrcon -c -H 127.0.0.1 -P <%= scope['minecraft::rcon_port'] %> -p <%= scope['minecraft::rcon_pass'] %> '/stop' ; /bin/true
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Introduction of a systemd unit to manage
minecraft service.

Makes use of the `mcrcon` utility to shutdown the service.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
