### PR TITLE
Add manage_screen parameter to controle screen package control

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,6 +5,7 @@ class minecraft (
   $source               = '1.7.4',          # Minecraft (semvar) or CraftBukkit ('recommended', 'beta', or 'dev'), or direct source (URL for wget)
   $autostart            = true,             # Start service at boot
   $manage_java          = true,             # Manage the JRE package
+  $manage_screen        = true,             # Manage the screen package
   $heap_size            = '1024',           # The maximum Java heap size in MB
   $heap_start           = '256',            # The initial Java heap size in MB
   $plugins              = {},               # Hash of plugins
@@ -49,7 +50,8 @@ class minecraft (
   $gen_structures       = true,
   $view_distance        = 10,
   $spawn_protection     = 16,
-$motd                 = 'A Minecraft Server') {
+  $motd                 = 'A Minecraft Server') {
+
   include minecraft::packages
   include minecraft::properties
   include minecraft::service

--- a/manifests/packages.pp
+++ b/manifests/packages.pp
@@ -6,5 +6,7 @@ class minecraft::packages {
     }
   }
 
-  ensure_packages('screen')
+  if $minecraft::manage_screen {
+    ensure_packages('screen')
+  }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Wrap `ensure_packages` call for screen into a `manage_screen` setting. I use ensure_packages() but it still conflicts because this module doesnot use `ensure` in it.

#### This Pull Request (PR) fixes the following issues
Fixes #12 
